### PR TITLE
Fix: @properties and categorize them as attributes

### DIFF
--- a/src/mkdocstrings_handlers/python/templates/material/_base/children.html
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/children.html
@@ -22,6 +22,11 @@
               {% include "attribute.html" with context %}
             {% endif %}
           {% endfor %}
+          {% for function in obj.functions.values()|order_members(config.members_order) %}
+            {% if "property" in function.labels %}
+              {% include "function.html" with context %}
+            {% endif %}
+          {% endfor %}
         {% endwith %}
 
         {% if config.show_category_heading and obj.classes.values() %}
@@ -42,7 +47,9 @@
           {% for function in obj.functions.values()|order_members(config.members_order) %}
             {% if not (obj.kind.value == "class" and function.name == "__init__" and config.merge_init_into_class) %}
               {% if not function.is_alias or function.is_explicitely_exported %}
-                {% include "function.html" with context %}
+                {% if not "property" in function.labels %}
+                  {% include "function.html" with context %}
+                {% endif %}
               {% endif %}
             {% endif %}
           {% endfor %}

--- a/src/mkdocstrings_handlers/python/templates/material/_base/children.html
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/children.html
@@ -13,7 +13,7 @@
           {% set extra_level = 0 %}
         {% endif %}
 
-        {% if config.show_category_heading and obj.attributes.values()|any %}
+        {% if config.show_category_heading and obj.attributes.values() %}
           {% filter heading(heading_level, id=html_id ~ "-attributes") %}Attributes{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
@@ -24,7 +24,7 @@
           {% endfor %}
         {% endwith %}
 
-        {% if config.show_category_heading and obj.classes.values()|any %}
+        {% if config.show_category_heading and obj.classes.values() %}
           {% filter heading(heading_level, id=html_id ~ "-classes") %}Classes{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
@@ -35,7 +35,7 @@
           {% endfor %}
         {% endwith %}
 
-        {% if config.show_category_heading and obj.functions.values()|any %}
+        {% if config.show_category_heading and obj.functions.values() %}
           {% filter heading(heading_level, id=html_id ~ "-functions") %}Functions{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
@@ -49,7 +49,7 @@
         {% endwith %}
 
         {% if config.show_submodules %}
-          {% if config.show_category_heading and obj.modules.values()|any %}
+          {% if config.show_category_heading and obj.modules.values() %}
             {% filter heading(heading_level, id=html_id ~ "-modules") %}Modules{% endfilter %}
           {% endif %}
           {% with heading_level = heading_level + extra_level %}

--- a/src/mkdocstrings_handlers/python/templates/material/_base/function.html
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/function.html
@@ -1,8 +1,18 @@
 {{ log.debug("Rendering " + function.path) }}
 {% if config.show_if_no_docstring or function.has_docstrings %}
 
+  {% set ns = namespace(is_property=False) %}
+  {% if "property" in function.labels %}
+    {% set ns.is_property = True %}
+  {% endif %}
+
+  {% if ns.is_property %}
+  <div class="doc doc-object doc-attribute">
+  {% else %}
   <div class="doc doc-object doc-function">
-  {% with html_id = function.path %}
+  {% endif %}
+
+    {% with html_id = function.path %}
 
     {% if not root or config.show_root_heading %}
 
@@ -16,27 +26,40 @@
         {% set show_full_path = config.show_object_full_path %}
       {% endif %}
 
-      {% filter heading(heading_level,
-          role="function",
-          id=html_id,
-          class="doc doc-heading",
-          toc_label=function.name ~ "()") %}
-
-        {% if config.separate_signature %}
-          {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
-        {% else %}
-          {% filter highlight(language="python", inline=True) %}
+      {% if ns.is_property %}
+        {% filter heading(heading_level, role="attribute", id=html_id, class="doc doc-heading", toc_label=function.name) %}
+          {% if config.separate_signature %}
             {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
-            {% include "signature.html" with context %}
-          {% endfilter %}
-        {% endif %}
+          {% else %}
+            {% filter highlight(language="python", inline=True) %}
+              {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
+              {% include "signature.html" with context %}
+            {% endfilter %}
+          {% endif %}
 
-        {% with labels = function.labels %}
-          {% include "labels.html" with context %}
-        {% endwith %}
+          {% with labels = function.labels %}
+            {% include "labels.html" with context %}
+          {% endwith %}
+        {% endfilter %}
 
-      {% endfilter %}
+      {% else %}
+        {% filter heading(heading_level, role="function", id=html_id, class="doc doc-heading", toc_label=function.name ~ "()") %}
 
+          {% if config.separate_signature %}
+            {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
+          {% else %}
+            {% filter highlight(language="python", inline=True) %}
+              {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
+              {% include "signature.html" with context %}
+            {% endfilter %}
+          {% endif %}
+
+          {% with labels = function.labels %}
+            {% include "labels.html" with context %}
+          {% endwith %}
+
+        {% endfilter %}      
+      {% endif %}
       {% if config.separate_signature %}
         {% filter highlight(language="python", inline=False) %}
           {% filter format_signature(config.line_length) %}        
@@ -48,12 +71,21 @@
 
     {% else %}
       {% if config.show_root_toc_entry %}
-        {% filter heading(heading_level,
-            role="function",
-            id=html_id,
-            toc_label=function.path,
-            hidden=True) %}
-        {% endfilter %}
+        {% if ns.is_property %}
+          {% filter heading(heading_level,
+              role="attribute",
+              id=html_id,
+              toc_label=function.path,
+              hidden=True) %}
+          {% endfilter %}
+        {% else %}
+          {% filter heading(heading_level,
+              role="function",
+              id=html_id,
+              toc_label=function.path,
+              hidden=True) %}
+          {% endfilter %}
+        {% endif %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}
     {% endif %}

--- a/src/mkdocstrings_handlers/python/templates/material/_base/signature.html
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/signature.html
@@ -8,7 +8,7 @@
       {%- set ns.equal = " = " -%}
     {%- endif -%}
 
-    (
+    {% if not "property" in function.labels %}({% endif %}
       {%- for parameter in function.parameters -%}
         {%- if parameter.name not in ("self", "cls") or loop.index0 > 0 or not (function.parent and function.parent.is_class) -%}
 
@@ -37,7 +37,7 @@
 
         {%- endif -%}
       {%- endfor -%}
-    )
+    {% if not "property" in function.labels %}){% endif %}
     {%- if config.show_signature_annotations and function.annotation %} -> {{ function.annotation|safe }}{%- endif -%}
 
   {%- endwith -%}


### PR DESCRIPTION
Fixes https://github.com/mkdocstrings/python/issues/14, Fixes https://github.com/mkdocstrings/python/issues/9

We classify if functions are a `@property` by checking if they have `property` in labels.

Fixes:
- `@property` now shows correctly alongside the attributes
- `@property` renders correctly with CSS class `doc-attribute`
- `@property` doesn't show parens anymore
- All objects are not properly categorized (see issue#14)

For material theme only for now