### PR TITLE
feat: Add support for globs in paths configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,8 +83,6 @@ plugins:
         - https://mkdocstrings.github.io/objects.inv
         - https://mkdocstrings.github.io/griffe/objects.inv
         options:
-          paths:
-            - src/*
           docstring_style: google
           docstring_options:
             ignore_init_summary: yes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,8 @@ plugins:
         - https://mkdocstrings.github.io/objects.inv
         - https://mkdocstrings.github.io/griffe/objects.inv
         options:
+          paths:
+            - src/*
           docstring_style: google
           docstring_options:
             ignore_init_summary: yes

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import glob
 import os
 import posixpath
 import re
@@ -127,6 +128,8 @@ class PythonHandler(BaseHandler):
         super().__init__(*args, **kwargs)
         self._config_file_path = config_file_path
         paths = paths or []
+        resolved_globs = [glob.glob(path) for path in paths]
+        paths = [path for glob_list in resolved_globs for path in glob_list]
         if not paths and config_file_path:
             paths.append(os.path.dirname(config_file_path))
         search_paths = [path for path in sys.path if path]  # eliminate empty path


### PR DESCRIPTION
This change allows for values in the paths configuration option to be
globs by resolving them before passing them off to griffe.

fixes #33 