### PR TITLE
Fix edit page link to python files for reference pages

### DIFF
--- a/docs/gen_ref_nav.py
+++ b/docs/gen_ref_nav.py
@@ -26,7 +26,7 @@ for path in sorted(Path("src").rglob("*.py")):
         ident = ".".join(parts)
         fd.write(f"::: {ident}")
 
-    mkdocs_gen_files.set_edit_path(full_doc_path, path)
+    mkdocs_gen_files.set_edit_path(full_doc_path, ".." / path)
 
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())


### PR DESCRIPTION
We need to provide a relative path to go up out of the docs dir.

See
https://github.com/mkdocstrings/mkdocstrings/pull/443