### PR TITLE
fix: globs in path if cwd is not the cfg file loc

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -3,7 +3,7 @@
 import pytest
 from griffe.docstrings.dataclasses import DocstringSectionExamples, DocstringSectionKind
 
-from mkdocstrings_handlers.python.handler import CollectionError, get_handler
+from mkdocstrings_handlers.python.handler import CollectionError, PythonHandler, get_handler
 
 
 def test_collect_missing_module():
@@ -58,3 +58,28 @@ def test_render_docstring_examples_section(handler):
     assert "<p>This is an example.</p>" in rendered
     assert "print" in rendered
     assert "Hello" in rendered
+
+
+def test_expand_globs(tmp_path):
+    """Assert globs are correctly expanded.
+
+    Parameters:
+        tmp_path: Pytext fixture that creates a temporary directory.
+    """
+    globbed_names = (
+        "expanded_a",
+        "expanded_b",
+        "other_expanded_c",
+        "other_expanded_d",
+    )
+    globbed_paths = [tmp_path.joinpath(globbed_name) for globbed_name in globbed_names]
+    for path in globbed_paths:
+        path.touch()
+    handler = PythonHandler(
+        handler="python",
+        theme="material",
+        config_file_path=tmp_path / "mkdocs.yml",
+        paths=["*exp*"],
+    )
+    for path in globbed_paths:  # noqa: WPS440
+        assert str(path) in handler._paths  # noqa: WPS437


### PR DESCRIPTION
fix #42 

based on the documentation: "Non-absolute paths are computed as relative to MkDocs configuration file."