### PR TITLE
fix: ensure dirname(config_file_path) is not empty

### DIFF
--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -145,7 +145,7 @@ class PythonHandler(BaseHandler):
         super().__init__(*args, **kwargs)
         self._config_file_path = config_file_path
         paths = paths or []
-        with chdir(os.path.dirname(config_file_path) if config_file_path else "."):
+        with chdir((os.path.dirname(config_file_path) or ".") if config_file_path else "."):
             resolved_globs = [glob.glob(path) for path in paths]
         paths = [path for glob_list in resolved_globs for path in glob_list]
         if not paths and config_file_path:

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -145,7 +145,8 @@ class PythonHandler(BaseHandler):
         super().__init__(*args, **kwargs)
         self._config_file_path = config_file_path
         paths = paths or []
-        with chdir((os.path.dirname(config_file_path) or ".") if config_file_path else "."):
+        glob_base_dir = os.path.dirname(os.path.abspath(config_file_path)) if config_file_path else "."
+        with chdir(glob_base_dir):
             resolved_globs = [glob.glob(path) for path in paths]
         paths = [path for glob_list in resolved_globs for path in glob_list]
         if not paths and config_file_path:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,5 +1,8 @@
 """Tests for the `handler` module."""
 
+import os
+from glob import glob
+
 import pytest
 from griffe.docstrings.dataclasses import DocstringSectionExamples, DocstringSectionKind
 
@@ -83,3 +86,15 @@ def test_expand_globs(tmp_path):
     )
     for path in globbed_paths:  # noqa: WPS440
         assert str(path) in handler._paths  # noqa: WPS437
+
+
+def test_expand_globs_without_changing_directory():
+    """Assert globs are correctly expanded when we are already in the right directory."""
+    handler = PythonHandler(
+        handler="python",
+        theme="material",
+        config_file_path="mkdocs.yml",
+        paths=["*.md"],
+    )
+    for path in list(glob(os.path.abspath(".") + "/*.md")):
+        assert path in handler._paths  # noqa: WPS437


### PR DESCRIPTION
Using `os.chdir` to switch to the directory containing the config file (introduced in #43) fails if `config_file_path` only contains a filename but no directories (similar to timvink/mkdocs-table-reader-plugin#16). Replacing an empty result of `os.dirname` should avoid this.