### PR TITLE
feat: Allow resolving alias to external modules

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -262,6 +262,14 @@
               "markdownDescription": "https://mkdocstrings.github.io/python/usage/#globallocal-options",
               "enum": ["brief", "source"],
               "default": "brief"
+            },
+            "preload_modules": {
+              "title": "Pre-load modules. It permits to resolve aliases pointing to these modules (packages), and therefore render members of an object that are external to the given object (originating from another package).",
+              "markdownDescription": "https://mkdocstrings.github.io/python/usage/#globallocal-options",
+              "type": "array",
+              "items": {
+                "type":"string"
+              }
             }
           },
           "additionalProperties": false

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -99,6 +99,7 @@ class PythonHandler(BaseHandler):
         "members": None,
         "filters": ["!^_[^_]"],
         "annotations_path": "brief",
+        "preload_modules": None,
     }
     """
     Attributes: Headings options:
@@ -150,6 +151,16 @@ class PythonHandler(BaseHandler):
     Attributes: Additional options:
         show_bases (bool): Show the base classes of a class. Default: `True`.
         show_source (bool): Show the source code of this object. Default: `True`.
+        preload_modules (list[str] | None): Pre-load modules that are
+            not specified directly in autodoc instructions (`::: identifier`).
+            It is useful when you want to render documentation for a particular member of an object,
+            and this member is imported from another package than its parent.
+
+            For an imported member to be rendered, you need to add it to the `__all__` attribute
+            of the importing module.
+
+            The modules must be listed as an array of strings. Default: `None`.
+
     """  # noqa: E501
 
     def __init__(
@@ -235,7 +246,10 @@ class PythonHandler(BaseHandler):
                 modules_collection=self._modules_collection,
                 lines_collection=self._lines_collection,
             )
-            try:
+            try:  # noqa: WPS229 we expect one type of exception, and want to fail on the first one
+                for pre_loaded_module in final_config.get("preload_modules") or []:
+                    if pre_loaded_module not in self._modules_collection:
+                        loader.load_module(pre_loaded_module)
                 loader.load_module(module_name)
             except ImportError as error:
                 raise CollectionError(str(error)) from error


### PR DESCRIPTION
Hi

I would like to suggest adding an option (false by default) to set griffe's resolve external modules flag to true.

What are your thoughts about it? Did I do it correctly? As I am not a native English speaker, my documentation my need some improvement.