### PR TITLE
refactor: Switch to an info level log for when black's not installed

### DIFF
--- a/src/mkdocstrings_handlers/python/rendering.py
+++ b/src/mkdocstrings_handlers/python/rendering.py
@@ -202,7 +202,7 @@ def _get_black_formatter() -> Callable[[str, int], str]:
     try:
         from black import Mode, format_str
     except ModuleNotFoundError:
-        logger.warning("Formatting signatures requires Black to be installed.")
+        logger.info("Formatting signatures requires Black to be installed.")
         return lambda text, _: text
 
     def formatter(code: str, line_length: int) -> str:


### PR DESCRIPTION
Lowering this to info level avoids this causing strict MkDocs builds to fail
