### PR TITLE
Show labels in deterministic order

### DIFF
--- a/src/mkdocstrings_handlers/python/templates/material/_base/labels.html
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/labels.html
@@ -1,7 +1,7 @@
 {% if labels %}
   {{ log.debug("Rendering labels") }}
   <span class="doc doc-labels">
-    {% for label in labels %}
+    {% for label in labels|sort %}
       <small class="doc doc-label doc-label-{{ label }}"><code>{{ label }}</code></small>
     {% endfor %}
   </span>


### PR DESCRIPTION
These labels are `set`s which have no defined order. Define *some* order, so they don't flip-flop depending on the environment.

https://github.com/mkdocs/regressions/actions/runs/5212332561/jobs/9405787375