### PR TITLE
feat: add default values, if any, when showing parameters as a list

### DIFF
--- a/src/mkdocstrings_handlers/python/templates/material/_base/docstring/parameters.html
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/docstring/parameters.html
@@ -60,6 +60,14 @@
         <div class="doc-md-description">
           {{ parameter.description|convert_markdown(heading_level, html_id) }}
         </div>
+        {% if parameter.default %}
+          <p>
+            <b>{{ lang.t("DEFAULT:") }}</b>
+            {% with expression = parameter.default %}
+              <code>{% include "expression.html" with context %}</code>
+            {% endwith %}
+          </p>
+        {% endif %}
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
The defaults are shown for table and spacy but not for list.