### PR TITLE
Make extension paths relative to config file

### DIFF
--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -9,7 +9,7 @@ import re
 import sys
 from collections import ChainMap
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar, Iterator, Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar, Iterator, Mapping, Sequence
 
 from griffe.collections import LinesCollection, ModulesCollection
 from griffe.docstrings.parsers import Parser
@@ -263,10 +263,11 @@ class PythonHandler(BaseHandler):
         parser_name = final_config["docstring_style"]
         parser_options = final_config["docstring_options"]
         parser = parser_name and Parser(parser_name)
+        extensions = self.normalize_extension_paths(final_config.get("extensions", []))
 
         if unknown_module:
             loader = GriffeLoader(
-                extensions=load_extensions(final_config.get("extensions", [])),
+                extensions=load_extensions(extensions),
                 search_paths=self._paths,
                 docstring_parser=parser,
                 docstring_options=parser_options,
@@ -368,6 +369,32 @@ class PythonHandler(BaseHandler):
         except AliasResolutionError:
             return tuple(anchors)
         return tuple(anchors)
+
+    def normalize_extension_paths(self, extensions: Sequence) -> Sequence:
+        """ Resolve paths relative to config file. """
+        if self._config_file_path is None:
+            return extensions
+        base_path = os.path.dirname(self._config_file_path)
+        normalized = []
+        for ext in extensions:
+            if isinstance(ext, dict):
+                pth, options = next(iter(ext.items()))
+                pth = str(pth)
+            else:
+                pth = str(ext)
+                options = None
+
+            if '.py' in pth or '/' in pth or '\\' in pth:
+                # This is a sytem path. Normalize it.
+                if not os.path.isabs(pth):
+                    # Make path absolute relative to config file path.
+                    pth = os.path.normpath(os.path.join(base_path, pth))
+
+            if options is not None:
+                normalized.append({pth: options})
+            else:
+                normalized.append(pth)
+        return normalized
 
 
 def get_handler(

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -263,9 +263,9 @@ class PythonHandler(BaseHandler):
         parser_name = final_config["docstring_style"]
         parser_options = final_config["docstring_options"]
         parser = parser_name and Parser(parser_name)
-        extensions = self.normalize_extension_paths(final_config.get("extensions", []))
 
         if unknown_module:
+            extensions = self.normalize_extension_paths(final_config.get("extensions", []))
             loader = GriffeLoader(
                 extensions=load_extensions(extensions),
                 search_paths=self._paths,

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -371,11 +371,13 @@ class PythonHandler(BaseHandler):
         return tuple(anchors)
 
     def normalize_extension_paths(self, extensions: Sequence) -> Sequence:
-        """ Resolve paths relative to config file. """
+        """Resolve extension paths relative to config file."""
         if self._config_file_path is None:
             return extensions
+
         base_path = os.path.dirname(self._config_file_path)
         normalized = []
+
         for ext in extensions:
             if isinstance(ext, dict):
                 pth, options = next(iter(ext.items()))
@@ -384,7 +386,7 @@ class PythonHandler(BaseHandler):
                 pth = str(ext)
                 options = None
 
-            if '.py' in pth or '/' in pth or '\\' in pth:
+            if pth.endswith(".py") or ".py:" in pth or "/" in pth or "\\" in pth:  # noqa: SIM102
                 # This is a sytem path. Normalize it.
                 if not os.path.isabs(pth):
                     # Make path absolute relative to config file path.
@@ -394,6 +396,7 @@ class PythonHandler(BaseHandler):
                 normalized.append({pth: options})
             else:
                 normalized.append(pth)
+
         return normalized
 
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -105,3 +105,34 @@ def test_expand_globs_without_changing_directory() -> None:
     )
     for path in list(glob(os.path.abspath(".") + "/*.md")):
         assert path in handler._paths
+
+
+def test_extension_paths(tmp_path: Path) -> None:
+    """Assert extension paths are resolved relative to config file."""
+    handler = get_handler(
+        theme="material",
+        config_file_path=str(tmp_path.joinpath("mkdocs.yml"))
+    )
+    extensions = [
+        "path/to/extension.py",
+        "path/to/extension.py:SomeExtension",
+        {"path/to/extension.py": {"option": "value"}},
+        {"path/to/extension.py:SomeExtension": {"option": "value"}},
+        "/absolute/path/to/extension.py",
+        "/absolute/path/to/extension.py:SomeExtension",
+        {"/absolute/path/to/extension.py": {"option": "value"}},
+        {"/absolute/path/to/extension.py:SomeExtension": {"option": "value"}},
+        "dot.notation.path.to.extension"
+    ]
+    result = handler.normalize_extension_paths(extensions)
+    assert result == [
+        str(tmp_path.joinpath("path/to/extension.py")),
+        str(tmp_path.joinpath("path/to/extension.py:SomeExtension")),
+        {str(tmp_path.joinpath("path/to/extension.py")): {"option": "value"}},
+        {str(tmp_path.joinpath("path/to/extension.py:SomeExtension")): {"option": "value"}},
+        "/absolute/path/to/extension.py",
+        "/absolute/path/to/extension.py:SomeExtension",
+        {"/absolute/path/to/extension.py": {"option": "value"}},
+        {"/absolute/path/to/extension.py:SomeExtension": {"option": "value"}},
+        "dot.notation.path.to.extension"
+    ]


### PR DESCRIPTION
There were a few different ways to accomplish this.

1. Modify griffe to have it accept a base_path (which defaults to CWD) and resolve paths relative to it.
2. Modify mkdocsstrings-python to resolve paths so that only absolute paths are passed to griffe.

Ultimately I went with the second option as griffe does not know about (and has no need to know about) mkdocstrings. It seems reasonable to me that griffe should expect to receive already resolved paths. As mkdocstrings-python is the glue between mkdocstrings and griffe, I thought that would be the most logical place to address the issue.

That said, much of the logic to separate the path from the rest of the data in the config options replicates the logic in `griffe.extensions.load_extensions()`. From a code efficiency point-of-view, it might have been the better to address this in griffe directly. However, I went from the logical API point-of-view. If the desire is to go the other way, let me know and I can do that.

Now, on to the actual fix itself...

The logical place to do this in mkdocstrings-python would be in config validation. However, there is no config validation for mkdocstring handlers at all. Building config validation would be a much bigger job than I want to tackle at this time. The next logical place to address this is where the extensions are actually accessed for the first time. Strangely, the handler class makes no mention of them anywhere (in attributes or the `__init__` method). They are only referenced in the `collect` method which accepts them as an argument. I could have inserted the code inline within the `collect` method, but testing would have been difficult (mock objects with all sorts of hoops to trick the test). Therefore, I broke the functionality out into a separate method, which makes it easy to test. As an additional benefit, any future config validation can just call the existing method. Even if a general purpose config validation was added, we would still need this custom code. The extension config option does not just accept simple paths and so any validation code would need to be custom crafted for this option anyway. Well, now that custom code exists.

Finally, I will note that this code does not account for any of the extensions to be a Python object. It assumes each one is a string (either system path or Python dot notation). Of course, as we are getting the values from a config file, that is a reasonable assumption. However, it does mean that users cannot use YAML's special `!!python`  function to pass in a Python object. If we want to allow that, then we need to import the various griffe extensions and type-check the values against them before processing values as strings. But given that users can already use both system paths and dot notation with a colon to specify a specific class, I see no need for that as well. I am simply pointing this out as it was possible  before, but is no longer possible with the current fix in place.

I should also mention that paths which are already absolute are left unaltered. In other words, if a user is using mkdocs custom `$config_dir` variable to get absolute paths, that will continue to work. Although, with this fix that is no longer necessary. At least the user will not need to make changes to their config file upon update.