### PR TITLE
Dotted path relative references

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ plugins:
           inherited_members: true
           merge_init_into_class: true
           preload_modules: [mkdocstrings]
+          relative_crossrefs: true
           separate_signature: true
           show_root_heading: true
           show_root_full_path: false

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -63,6 +63,7 @@ class PythonHandler(BaseHandler):
     default_config: ClassVar[dict] = {
         "docstring_style": "google",
         "docstring_options": {},
+        "relative_crossrefs": True,
         "show_symbol_type_heading": False,
         "show_symbol_type_toc": False,
         "show_root_heading": False,
@@ -158,6 +159,7 @@ class PythonHandler(BaseHandler):
         docstring_options (dict): The options for the docstring parser. See parsers under [`griffe.docstrings`][].
         docstring_section_style (str): The style used to render docstring sections. Options: `table`, `list`, `spacy`. Default: `"table"`.
         merge_init_into_class (bool): Whether to merge the `__init__` method into the class' signature and docstring. Default: `False`.
+        relative_crossrefs (bool): Whether to expand `.`-prefixed references relative to the qualname and import path. Default: `True`.
         show_if_no_docstring (bool): Show the object heading even if it has no docstring or children with docstrings. Default: `False`.
         show_docstring_attributes (bool): Whether to display the "Attributes" section in the object's docstring. Default: `True`.
         show_docstring_functions (bool): Whether to display the "Functions" or "Methods" sections in the object's docstring. Default: `True`.


### PR DESCRIPTION
I have begun to develop the new simplified form of relative cross-reference and think it should default to on, because as I see it this cannot cause backward incompatibility: it was invalid to use a `.`-prefixed reference in a docstring before now, so surely there is no pre-existing code whose behaviour we need to preserve? Can I confirm that's the case?

- feat(relative-refs): add and document a new `relative_crossrefs` config setting

This PR will close #27:

- [Relative cross-references](https://github.com/mkdocstrings/python/issues/27)