### PR TITLE
Fix link to griffe.Parsers in docstrings options summary

### DIFF
--- a/docs/usage/customization.md
+++ b/docs/usage/customization.md
@@ -302,7 +302,7 @@ and the Jinja context available in their scope.
 Available context:
 
 - `config`: The handler configuration (dictionary).
-- `module`: The [Module][griffe.dataclasses.Module] instance.
+- `module`: The [Module][griffe.Module] instance.
 
 #### `class.html`
 
@@ -319,7 +319,7 @@ Available context:
 Available context:
 
 - `config`: The handler configuration (dictionary).
-- `class`: The [Class][griffe.dataclasses.Class] instance.
+- `class`: The [Class][griffe.Class] instance.
 
 #### `function.html`
 
@@ -333,7 +333,7 @@ Available context:
 Available context:
 
 - `config`: The handler configuration (dictionary).
-- `function`: The [Function][griffe.dataclasses.Function] instance.
+- `function`: The [Function][griffe.Function] instance.
 
 #### `attribute.html`
 
@@ -346,7 +346,7 @@ Available context:
 Available context:
 
 - `config`: The handler configuration (dictionary).
-- `attribute`: The [Attribute][griffe.dataclasses.Attribute] instance.
+- `attribute`: The [Attribute][griffe.Attribute] instance.
 
 #### Docstring sections
 
@@ -368,7 +368,7 @@ and `docstring/yields.html`:
 
 Available context:
 
-- `section`: The [DocstringSection][griffe.docstrings.dataclasses.DocstringSection] instance (see `DocstringSection*` subclasses).
+- `section`: The [DocstringSection][griffe.DocstringSection] instance (see `DocstringSection*` subclasses).
 
 ### Syntax highlight in signatures
 

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -162,7 +162,7 @@ class PythonHandler(BaseHandler):
 
     Attributes: Docstrings options:
         docstring_style (str): The docstring style to use: `google`, `numpy`, `sphinx`, or `None`. Default: `"google"`.
-        docstring_options (dict): The options for the docstring parser. See parsers under [`griffe.docstrings`][].
+        docstring_options (dict): The options for the docstring parser. See parsers under [`griffe.Parser`][].
         docstring_section_style (str): The style used to render docstring sections. Options: `table`, `list`, `spacy`. Default: `"table"`.
         merge_init_into_class (bool): Whether to merge the `__init__` method into the class' signature and docstring. Default: `False`.
         show_if_no_docstring (bool): Show the object heading even if it has no docstring or children with docstrings. Default: `False`.

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -162,7 +162,7 @@ class PythonHandler(BaseHandler):
 
     Attributes: Docstrings options:
         docstring_style (str): The docstring style to use: `google`, `numpy`, `sphinx`, or `None`. Default: `"google"`.
-        docstring_options (dict): The options for the docstring parser. See parsers under [`griffe.Parser`][].
+        docstring_options (dict): The options for the docstring parser. See [docstring parsers](https://mkdocstrings.github.io/griffe/reference/docstrings/) and their options in Griffe docs.
         docstring_section_style (str): The style used to render docstring sections. Options: `table`, `list`, `spacy`. Default: `"table"`.
         merge_init_into_class (bool): Whether to merge the `__init__` method into the class' signature and docstring. Default: `False`.
         show_if_no_docstring (bool): Show the object heading even if it has no docstring or children with docstrings. Default: `False`.


### PR DESCRIPTION
This link is currently resulting in a 404 - please let me know if this is not the right page to link to. Cheers!