### PR TITLE
fix: Don't merge parent `__init__` docstring into class docstring if such inherited method wasn't selected through the `inherited_members` configuration option

### DIFF
--- a/src/mkdocstrings_handlers/python/templates/material/_base/class.html.jinja
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/class.html.jinja
@@ -132,13 +132,17 @@ Context:
             {% include "docstring"|get_template with context %}
           {% endwith %}
           {% if config.merge_init_into_class %}
-            {% if "__init__" in all_members and all_members["__init__"].has_docstring %}
-              {% with function = all_members["__init__"] %}
-                {% with obj = function, docstring_sections = function.docstring.parsed %}
-                  {% include "docstring"|get_template with context %}
+            {# We don't want to merge the inherited `__init__` method docstring into the class docstring #}
+            {# if such inherited method was not selected through `inherited_members`. #}
+            {% with check_members = all_members if (config.inherited_members is true or (config.inherited_members is iterable and "__init__" in config.inherited_members)) else class.members %}
+              {% if "__init__" in check_members and check_members["__init__"].has_docstring %}
+                {% with function = check_members["__init__"] %}
+                  {% with obj = function, docstring_sections = function.docstring.parsed %}
+                    {% include "docstring"|get_template with context %}
+                  {% endwith %}
                 {% endwith %}
-              {% endwith %}
-            {% endif %}
+              {% endif %}
+            {% endwith %}
           {% endif %}
         {% endblock docstring %}
 

--- a/src/mkdocstrings_handlers/python/templates/material/_base/class.html.jinja
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/class.html.jinja
@@ -18,7 +18,7 @@ Context:
 {% endblock logs %}
 
 <div class="doc doc-object doc-class">
-  {% with obj = class, html_id = class.path %}
+  {% with obj = class, html_id = class.path, all_members = class.all_members %}
 
     {% if root %}
       {% set show_full_path = config.show_root_full_path %}
@@ -49,8 +49,8 @@ Context:
           {% if config.show_symbol_type_heading %}<code class="doc-symbol doc-symbol-heading doc-symbol-class"></code>{% endif %}
           {% if config.separate_signature %}
             <span class="doc doc-object-name doc-class-name">{{ class_name }}</span>
-          {% elif config.merge_init_into_class and "__init__" in class.all_members %}
-            {% with function = class.all_members["__init__"] %}
+          {% elif config.merge_init_into_class and "__init__" in all_members %}
+            {% with function = all_members["__init__"] %}
               {%+ filter highlight(language="python", inline=True) %}
                 {{ class_name }}{% include "signature"|get_template with context %}
               {% endfilter %}
@@ -78,8 +78,8 @@ Context:
         This block renders the signature for the class.
         -#}
         {% if config.separate_signature and config.merge_init_into_class %}
-          {% if "__init__" in class.all_members %}
-            {% with function = class.all_members["__init__"] %}
+          {% if "__init__" in all_members %}
+            {% with function = all_members["__init__"] %}
               {% filter format_signature(function, config.line_length, crossrefs=config.signature_crossrefs) %}
                 {{ class.name }}
               {% endfilter %}
@@ -132,8 +132,8 @@ Context:
             {% include "docstring"|get_template with context %}
           {% endwith %}
           {% if config.merge_init_into_class %}
-            {% if "__init__" in class.all_members and class.all_members["__init__"].has_docstring %}
-              {% with function = class.all_members["__init__"] %}
+            {% if "__init__" in all_members and all_members["__init__"].has_docstring %}
+              {% with function = all_members["__init__"] %}
                 {% with obj = function, docstring_sections = function.docstring.parsed %}
                   {% include "docstring"|get_template with context %}
                 {% endwith %}
@@ -157,8 +157,8 @@ Context:
           -#}
           {% if config.show_source %}
             {% if config.merge_init_into_class %}
-              {% if "__init__" in class.all_members and class.all_members["__init__"].source %}
-                {% with init = class.all_members["__init__"] %}
+              {% if "__init__" in all_members and all_members["__init__"].source %}
+                {% with init = all_members["__init__"] %}
                   <details class="quote">
                     <summary>Source code in <code>
                       {%- if init.relative_filepath.is_absolute() -%}


### PR DESCRIPTION
Closes #189 