### PR TITLE
feat: allow  `force_inspection` option to be configurable

### DIFF
--- a/docs/usage/configuration/general.md
+++ b/docs/usage/configuration/general.md
@@ -55,6 +55,30 @@ plugins:
 ////
 ///
 
+## `force_inspection`
+
+- **:octicons-package-24: Type [`bool`][] :material-equal: `False`{ title="default value" }**
+<!-- - **:octicons-project-template-24: Template :material-null:** (contained in [`class.html`][class template]) -->
+
+Whether to force inspecting modules (importing them) even if their source code is available.
+
+This option is useful when you know that dynamic analysis (inspection) yields better results than static analysis. Do not use this blindly: the recommended approach is to write a Griffe extension that will improve extracted API data. See [How to selectively inspect objects](https://mkdocstrings.github.io/griffe/guide/users/how-to/selectively-inspect/).
+
+```yaml title="in mkdocs.yml (global configuration)"
+plugins:
+- mkdocstrings:
+    handlers:
+      python:
+        options:
+          force_inspection: false
+```
+
+```md title="or in docs/some_page.md (local configuration)"
+::: path.to.object
+    options:
+      force_inspection: true
+```
+
 ## `show_bases`
 
 - **:octicons-package-24: Type [`bool`][] :material-equal: `True`{ title="default value" }**

--- a/src/mkdocstrings_handlers/python/handler.py
+++ b/src/mkdocstrings_handlers/python/handler.py
@@ -116,6 +116,7 @@ class PythonHandler(BaseHandler):
         "annotations_path": "brief",
         "preload_modules": None,
         "allow_inspection": True,
+        "force_inspection": False,
         "summary": False,
         "show_labels": True,
         "unwrap_annotated": False,
@@ -127,6 +128,7 @@ class PythonHandler(BaseHandler):
     Attributes: General options:
         find_stubs_package (bool): Whether to load stubs package (package-stubs) when extracting docstrings. Default `False`.
         allow_inspection (bool): Whether to allow inspecting modules when visiting them is not possible. Default: `True`.
+        force_inspection (bool): Whether to force using dynamic analysis when loading data. Default: `False`.
         show_bases (bool): Show the base classes of a class. Default: `True`.
         show_inheritance_diagram (bool): Show the inheritance diagram of a class using Mermaid. Default: `False`.
         show_source (bool): Show the source code of this object. Default: `True`.
@@ -318,6 +320,7 @@ class PythonHandler(BaseHandler):
                 modules_collection=self._modules_collection,
                 lines_collection=self._lines_collection,
                 allow_inspection=final_config["allow_inspection"],
+                force_inspection=final_config["force_inspection"],
             )
             try:
                 for pre_loaded_module in final_config.get("preload_modules") or []:


### PR DESCRIPTION
## Add `force_inspection` flag to `PythonHandler` for `mkdocs.yml` configuration

### Rationale
The `force_inspection` argument cannot be configured directly via `mkdocs.yml`. This change introduces a straightforward way to pass the option by forwarding it to the `GriffeLoader`.

### Changes
- Added `force_inspection` to `PythonHandler.default_config` with a default value of `False`.
- Forwarded the `force_inspection` value to the `GriffeLoader` constructor.

Fixes #94