### PR TITLE
feat: remove annotations for properties in attributes section of summary

### DIFF
--- a/src/mkdocstrings_handlers/python/rendering.py
+++ b/src/mkdocstrings_handlers/python/rendering.py
@@ -539,11 +539,20 @@ def do_as_attributes_section(
     Returns:
         An attributes docstring section.
     """
+
+    def _parse_docstring_summary(attribute: Attribute) -> str:
+        if attribute.docstring is None:
+            return ""
+        line = attribute.docstring.value.split("\n", 1)[0]
+        if ":" in line and attribute.docstring.parser_options.get("returns_type_in_property_summary", False):
+            _, line = line.split(":", 1)
+        return line
+
     return DocstringSectionAttributes(
         [
             DocstringAttribute(
                 name=attribute.name,
-                description=attribute.docstring.value.split("\n", 1)[0] if attribute.docstring else "",
+                description=_parse_docstring_summary(attribute),
                 annotation=attribute.annotation,
                 value=attribute.value,  # type: ignore[arg-type]
             )


### PR DESCRIPTION
# Rationale
When `summary` is set to True in `mkdocs.yml`, one-line `@property` attributes are shown as they are without the stripping of the annotation. For example `str: xxxxxx` is shown as `str:xxxx` in the `Attributes` section of the summary. This PR strips out any annotations, effectively leaving the `xxxxxxx` part in the summary which is what is desired.

# Changes
- add helper function in `do_as_attributes_section` to parse the description from the docstring accounting for `@property` style docstrings too.