### PR TITLE
fix example usage of inventories

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -87,8 +87,8 @@ plugins:
 - mkdocstrings:
     handlers:
       python:
-        import:
-        - https://docs.python-requests.org/en/master/objects.inv
+        inventories:
+        - https://docs.python.org/3/objects.inv
 ```
 
 When loading an inventory, you enable automatic cross-references


### PR DESCRIPTION
I am currently working to integrate `mkdocstrings` to generate project documentation, and I was a bit confused by the example text that did not match the example code.