### PR TITLE
feat: Add llm_friendly_source option for LLM-compatible source rendering

### DIFF
--- a/docs/usage/configuration/general.md
+++ b/docs/usage/configuration/general.md
@@ -494,3 +494,62 @@ def some_function():
 <p>Docstring of the function.</p>
 ////
 ///
+
+[](){#option-llm_friendly_source}
+## `llm_friendly_source`
+
+- **:octicons-package-24: Type [`bool`][] :material-equal: `False`{ title="default value" }**
+<!-- - **:octicons-project-template-24: Template :material-null:** (contained in [`class.html`][class template] and  [`function.html`][function template]) -->
+
+When [`show_source`](#show_source) is enabled, render source code in a format more compatible with LLM-focused tools. This removes line numbers and uses simple markdown code blocks instead of complex HTML tables.
+
+This is particularly useful when using tools like mkdocs-llmstxt that convert documentation to LLM-friendly text formats.
+
+```yaml title="in mkdocs.yml (global configuration)"
+plugins:
+- mkdocstrings:
+    handlers:
+      python:
+        options:
+          show_source: true
+          llm_friendly_source: true
+```
+
+```md title="or in docs/some_page.md (local configuration)"
+::: path.to.object
+    options:
+      show_source: true
+      llm_friendly_source: true
+```
+
+/// admonition | Preview
+    type: preview
+
+//// tab | LLM-friendly source
+<h2><code>some_function()</code></h2>
+<p>Docstring of the function.</p>
+
+///// details | Source code in `package/module.py`
+    type: quote
+
+```python
+def some_function():
+    ...
+```
+/////
+////
+
+//// tab | Traditional source (with line numbers)
+<h2><code>some_function()</code></h2>
+<p>Docstring of the function.</p>
+
+///// details | Source code in `package/module.py`
+    type: quote
+
+```python linenums="1"
+def some_function():
+    ...
+```
+/////
+////
+///

--- a/src/mkdocstrings_handlers/python/_internal/config.py
+++ b/src/mkdocstrings_handlers/python/_internal/config.py
@@ -841,6 +841,14 @@ class PythonInputOptions:
         ),
     ] = True
 
+    llm_friendly_source: Annotated[
+        bool,
+        _Field(
+            group="general",
+            description="When show_source is enabled, render source code in a format more compatible with LLM-focused tools (no line numbers, simple markdown code blocks).",
+        ),
+    ] = False
+
     show_submodules: Annotated[
         bool,
         _Field(

--- a/src/mkdocstrings_handlers/python/templates/material/_base/class.html.jinja
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/class.html.jinja
@@ -200,7 +200,13 @@ Context:
                         {{ init.relative_filepath }}
                       {%- endif -%}
                     </code></summary>
-                    {{ init.source|highlight(language="python", linestart=init.lineno or 0, linenums=True) }}
+                    {% if config.llm_friendly_source %}
+                      <div class="language-python highlight">
+                        <pre><code class="language-python">{{ init.source }}</code></pre>
+                      </div>
+                    {% else %}
+                      {{ init.source|highlight(language="python", linestart=init.lineno or 0, linenums=True) }}
+                    {% endif %}
                   </details>
                 {% endwith %}
               {% endif %}
@@ -213,7 +219,13 @@ Context:
                     {{ class.relative_filepath }}
                   {%- endif -%}
                 </code></summary>
-                {{ class.source|highlight(language="python", linestart=class.lineno or 0, linenums=True) }}
+                {% if config.llm_friendly_source %}
+                  <div class="language-python highlight">
+                    <pre><code class="language-python">{{ class.source }}</code></pre>
+                  </div>
+                {% else %}
+                  {{ class.source|highlight(language="python", linestart=class.lineno or 0, linenums=True) }}
+                {% endif %}
               </details>
             {% endif %}
           {% endif %}

--- a/src/mkdocstrings_handlers/python/templates/material/_base/function.html.jinja
+++ b/src/mkdocstrings_handlers/python/templates/material/_base/function.html.jinja
@@ -153,7 +153,13 @@ Context:
                   {{ function.relative_filepath }}
                 {%- endif -%}
               </code></summary>
-              {{ function.source|highlight(language="python", linestart=function.lineno or 0, linenums=True) }}
+              {% if config.llm_friendly_source %}
+                <div class="language-python highlight">
+                  <pre><code class="language-python">{{ function.source }}</code></pre>
+                </div>
+              {% else %}
+                {{ function.source|highlight(language="python", linestart=function.lineno or 0, linenums=True) }}
+              {% endif %}
             </details>
           {% endif %}
         {% endblock source %}

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -176,6 +176,30 @@ def test_rendering_object_source_without_lineno(handler: PythonHandler) -> None:
         assert handler.render(module, PythonOptions(show_source=True))
 
 
+def test_llm_friendly_source_rendering(handler: PythonHandler) -> None:
+    """Test LLM-friendly source code rendering."""
+    code = dedent(
+        """
+        class Example:
+            '''Example class.'''
+
+            def method(self):
+                '''Example method.'''
+                return "hello"
+        """,
+    )
+    with temporary_visited_module(code) as module:
+        # Test traditional rendering (with line numbers)
+        traditional_html = handler.render(module["Example"], PythonOptions(show_source=True, llm_friendly_source=False))
+        assert "linenums" in traditional_html or "lineno" in traditional_html
+
+        # Test LLM-friendly rendering (without line numbers, simple code blocks)
+        llm_friendly_html = handler.render(module["Example"], PythonOptions(show_source=True, llm_friendly_source=True))
+        assert '<pre><code class="language-python">' in llm_friendly_html
+        assert "linenums" not in llm_friendly_html
+        assert "lineno" not in llm_friendly_html
+
+
 def test_give_precedence_to_user_paths() -> None:
     """Assert user paths take precedence over default paths."""
     last_sys_path = sys.path[-1]


### PR DESCRIPTION
## Summary

This PR adds a new `llm_friendly_source` configuration option that addresses the compatibility issue between mkdocstrings source code rendering and LLM-focused tools like mkdocs-llmstxt.

## Problem

When using `show_source: true` with mkdocstrings-python, the mkdocs-llmstxt plugin generates suboptimal output in `llms-full.txt` files. Instead of clean, readable Python code blocks, source code gets converted into confusing table format with line numbers and compressed code.

## Solution

Added a new boolean configuration option `llm_friendly_source` that:
- **Removes line numbers** from source code displays
- **Uses simple markdown-style code blocks** instead of complex HTML tables
- **Maintains backward compatibility** (defaults to `False`)
- **Works alongside existing `show_source` option**

## Changes

- ✅ **Config**: Add `llm_friendly_source: bool = False` to `PythonInputOptions`
- ✅ **Templates**: Update function and class templates to conditionally render LLM-friendly source
- ✅ **Documentation**: Add comprehensive documentation with usage examples
- ✅ **Tests**: Add test coverage for both traditional and LLM-friendly rendering
- ✅ **Quality**: All linting, type checking, and documentation checks pass

## Usage

```yaml
# mkdocs.yml
plugins:
- mkdocstrings:
    handlers:
      python:
        options:
          show_source: true
          llm_friendly_source: true  # New option\!
```

## Before vs After

**Before (Traditional - problematic for LLM tools):**
```html
<table class="highlighttable">
  <tr><td class="linenos">1</td><td class="code">def function(): ...</td></tr>
</table>
```

**After (LLM-friendly):**
```html
<div class="language-python highlight">
  <pre><code class="language-python">def function(): ...</code></pre>
</div>
```

## Test Plan

- [x] All existing tests pass
- [x] New test verifies LLM-friendly rendering works
- [x] Code quality checks pass (Ruff, MyPy)
- [x] Documentation builds successfully
- [x] Feature works for both functions and classes

Fixes #299

🤖 Generated with [Claude Code](https://claude.ai/code)