### PR TITLE
ci: Fix test matrix compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/snapshots/** text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
 
     - name: Download objects inventory
       uses: actions/download-artifact@v4
+      if: ${{ matrix.resolution == 'highest' }}
       with:
         name: objects.inv
         path: site/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
           resolution: lowest-direct
         - os: windows-latest
           resolution: lowest-direct
+        - python-version: "3.14"
+          resolution: lowest-direct
+        - python-version: "3.15"
+          resolution: lowest-direct
     runs-on: ${{ matrix.os }}
     continue-on-error: true
 

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -40,7 +40,7 @@ def environ(**kwargs: str) -> Iterator[None]:
 
 def uv_install(venv: Path) -> None:
     """Install dependencies using uv."""
-    with environ(UV_PROJECT_ENVIRONMENT=str(venv), PYO3_USE_ABI3_FORWARD_COMPATIBILITY="1"):
+    with environ(UV_PROJECT_ENVIRONMENT=str(venv)):
         if "CI" in os.environ:
             shell("uv sync --no-editable")
         else:


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [ ] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

Fix unrelated CI matrix failures discovered while validating #334:

- Keep snapshot fixtures on LF line endings on Windows.
- Download the documentation inventory only in highest-resolution jobs, which are the only jobs that consume it.
- Remove the global PyO3 ABI3 override so current Pydantic releases build on Python 3.15.
- Exclude Python 3.14 and 3.15 from `lowest-direct`, because the minimum supported Pydantic stack does not build on those Python versions.

### Relevant resources
<!-- Link to any relevant GitHub issue, PR or discussion, section in online docs, etc. -->

- Split out of https://github.com/mkdocstrings/python/pull/334 at the maintainer's request.
- Green 31-job validation run before the split: https://github.com/mkdocstrings/python/actions/runs/29655904249
